### PR TITLE
Update base image to centos:7

### DIFF
--- a/dataverse-k8s/Dockerfile
+++ b/dataverse-k8s/Dockerfile
@@ -4,7 +4,7 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 
-FROM centos:7.5.1804
+FROM centos:7
 
 LABEL maintainer="FDM FZJ <forschungsdaten@fz-juelich.de>"
 


### PR DESCRIPTION
Closes #1.

This is related to IQSS/dataverse#5374. If this blows up, we'll return to 7.5.