### PR TITLE
36 - upgrade to upstream release v4.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Running Dataverse on Kubernetes
 
-[![Dataverse](https://img.shields.io/badge/Dataverse-v4.12-important.svg)](https://dataverse.org)
+[![Dataverse](https://img.shields.io/badge/Dataverse-v4.13-important.svg)](https://dataverse.org)
 [![Test Status](https://travis-ci.org/IQSS/dataverse-kubernetes.svg?branch=master)](https://travis-ci.org/IQSS/dataverse-kubernetes)
 [![Docker Hub Image](https://img.shields.io/static/v1.svg?label=image&message=dataverse-k8s&logo=docker)](https://cloud.docker.com/u/iqss/repository/docker/iqss/dataverse-k8s)
 [![Docker Hub Image](https://img.shields.io/static/v1.svg?label=image&message=solr-k8s&logo=docker)](https://cloud.docker.com/u/iqss/repository/docker/iqss/solr-k8s)

--- a/docker/dataverse-k8s/Dockerfile
+++ b/docker/dataverse-k8s/Dockerfile
@@ -9,7 +9,7 @@ FROM centos:7
 LABEL maintainer="FDM FZJ <forschungsdaten@fz-juelich.de>"
 
 ARG TINI_VERSION=v0.18.0
-ARG VERSION=4.12
+ARG VERSION=4.13
 ARG DOMAIN=domain1
 
 ENV HOME_DIR=/opt/dataverse\

--- a/docker/solr-k8s/Dockerfile
+++ b/docker/solr-k8s/Dockerfile
@@ -8,7 +8,7 @@ FROM solr:7.3.1
 
 LABEL maintainer="FDM FZJ <forschungsdaten@fz-juelich.de>"
 
-ARG VERSION=4.12
+ARG VERSION=4.13
 ARG COLLECTION=collection1
 ENV SOLR_OPTS="-Dsolr.jetty.request.header.size=102400"\
     COLLECTION_DIR=/opt/solr/server/solr/${COLLECTION}\

--- a/k8s/dataverse/deployment.yaml
+++ b/k8s/dataverse/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: dataverse
-          image: iqss/dataverse-k8s:4.12
+          image: iqss/dataverse-k8s:4.13
           ports:
             - containerPort: 8080
           envFrom:

--- a/k8s/dataverse/jobs/bootstrap.yaml
+++ b/k8s/dataverse/jobs/bootstrap.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: dv-bootstrap
-          image: iqss/dataverse-k8s:4.12
+          image: iqss/dataverse-k8s:4.13
           command: ["scripts/bootstrap-job.sh"]
           envFrom:
             - configMapRef:

--- a/k8s/dataverse/jobs/configure.yaml
+++ b/k8s/dataverse/jobs/configure.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: dv-bootstrap
-          image: iqss/dataverse-k8s:4.12
+          image: iqss/dataverse-k8s:4.13
           command: ["scripts/config-job.sh"]
           envFrom:
             - configMapRef:

--- a/k8s/solr/deployment.yaml
+++ b/k8s/solr/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: solr
-          image: iqss/solr-k8s:4.12
+          image: iqss/solr-k8s:4.13
           ports:
             - containerPort: 8983
           volumeMounts:


### PR DESCRIPTION
This can be merged once IQSS/dataverse has [fully released v4.13](https://github.com/IQSS/dataverse/releases/tag/v4.13). Currently, the dvinstall.zip is missing, thus our Docker images cannot be built.

@djbrooke I am adding you here as you pre-released yesterday... :wink: 