### PR TITLE
12 - Add documentation on usage with AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For production usage you really will want to fork and create your on deployments
 Example usages:
 * [Quick demo with Minikube](docs/minikube.md)
 * [Usage with minimized k3s](docs/k3s.md)
+* [Deploy to an Amazon EC2 based custom K8s cluster](docs/aws-kops.md)
 
 ### Upgrading your installation
 

--- a/docs/aws-demo/demo-secrets.yaml
+++ b/docs/aws-demo/demo-secrets.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dataverse-postgresql
+  labels:
+    app: dataverse
+type: Opaque
+stringData:
+  username: dataverse
+  password: changeme
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dataverse-doi
+  labels:
+    app: dataverse
+type: Opaque
+stringData:
+  username: test.doi
+  password: changeme
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dataverse-api
+  labels:
+    app: dataverse
+type: Opaque
+stringData:
+  key: supersecret

--- a/docs/aws-demo/kustomization.yaml
+++ b/docs/aws-demo/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+bases:
+  - ../../k8s/dataverse
+  - ../../k8s/solr
+  - ../../k8s/utils/postgresql
+
+resources:
+  - demo-secrets.yaml
+
+patches:
+  - patch-pvc-aws.yaml

--- a/docs/aws-demo/patch-pvc-aws.yaml
+++ b/docs/aws-demo/patch-pvc-aws.yaml
@@ -1,0 +1,24 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: postgresql
+spec:
+  storageClassName: gp2
+  selector:
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: dataverse-files
+spec:
+  storageClassName: gp2
+  selector:
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: solr
+spec:
+  storageClassName: gp2
+  selector:

--- a/docs/aws-kops.md
+++ b/docs/aws-kops.md
@@ -1,0 +1,39 @@
+# Run on custom AWS EC2 cluster
+
+Amazon offers virtual machines as EC2 instances and a managed Kubernetes cluster
+service.
+
+This HOWTO describes how to run Dataverse on a custom K8s cluster which is
+deployed by yourself and not managed by Amazon.
+
+## Use a tool to deploy an EC2 based K8s cluster
+
+At https://kubernetes.io/docs/setup/turnkey/aws you can find a list of tools
+how to deploy a cluster to AWS. As an example, we will use [kops](https://github.com/kubernetes/kops).
+
+Follow the [AWS instructions](https://github.com/kubernetes/kops/blob/master/docs/aws.md):
+1. Install `kops` and `kubectl`. Please install kubectl v1.14 or later so kustomize is usable (see below).
+2. For demo purposes, you can safely skip the DNS setup. Gossip DNS is sufficient.
+3. Choose a AWS region. You will need to use it throughout the lifetime of your cluster.
+  * `export KOPS_REGION=us-east-1`
+4. Create a S3 bucket using the region you choosed before:
+  * `aws s3api create-bucket --bucket prefix-example-com-state-store --region ${REGION}`
+5. Export name (beware to use k8s.local when using Gossip DNS) and state store location:
+  * `export NAME=myfirstcluster.k8s.local`
+  * `export KOPS_STATE_STORE=s3://prefix-example-com-state-store`
+6. Create a cluster description:
+  * `kops create cluster --kubernetes-version 1.13.5 --zones "${KOPS_REGION}a" --name ${NAME}`
+7. Apply and deploy:
+  * `kops update cluster ${NAME} --yes`
+
+Enjoy your cluster. "It should be ready in a few minutes" should be taken seriously.
+
+## Deploy Dataverse application to cluster
+
+Using kustomize, this is pretty easy and fast forward:
+```
+kubectl apply -k docs/aws-demo
+```
+
+This will deploy a default demo instance to your cluster. See also:
+[minikube demo](minikube.md) and [k3s demo](k3s.md).

--- a/docs/aws-kops.md
+++ b/docs/aws-kops.md
@@ -37,3 +37,15 @@ kubectl apply -k docs/aws-demo
 
 This will deploy a default demo instance to your cluster. See also:
 [minikube demo](minikube.md) and [k3s demo](k3s.md).
+
+When bootstrapping finished (see `kubectl get job,pod` and logs), simply do a
+port forwarding to access Dataverse:
+```
+kubectl port-forward service/dataverse 8080
+```
+
+Now you may point your favorite browser to http://localhost:8080 and enjoy
+your freshly backed Dataverse demo.
+
+Secrets are the same as documented in [minikube setup](minikube.md),
+[see also](aws-demo/demo-secrets.yaml).


### PR DESCRIPTION
Relates to #12.

This is based on the work on #26 using `kustomize` (thus the commits not related to #12).