### PR TITLE
77 - Updating images and manifests to upstream release v4.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Running Dataverse on Kubernetes
 
-[![Dataverse](https://img.shields.io/badge/Dataverse-v4.15-important.svg)](https://dataverse.org)
+[![Dataverse](https://img.shields.io/badge/Dataverse-v4.15.1-important.svg)](https://dataverse.org)
 [![Validation](https://jenkins.dataverse.org/job/dataverse-k8s/job/K8s%20Linting/badge/icon?subject=kubeval&status=valid&color=purple)](https://jenkins.dataverse.org/job/dataverse-k8s/job/K8s%20Linting/)
 [![Docker Hub Image](https://img.shields.io/static/v1.svg?label=image&message=dataverse-k8s&logo=docker)](https://hub.docker.com/r/iqss/dataverse-k8s)
 [![Docker Hub Image](https://img.shields.io/static/v1.svg?label=image&message=solr-k8s&logo=docker)](https://hub.docker.com/r/iqss/solr-k8s)

--- a/docker/dataverse-k8s/Dockerfile
+++ b/docker/dataverse-k8s/Dockerfile
@@ -9,7 +9,7 @@ FROM centos:7
 LABEL maintainer="FDM FZJ <forschungsdaten@fz-juelich.de>"
 
 ARG TINI_VERSION=v0.18.0
-ARG VERSION=4.15
+ARG VERSION=4.15.1
 ARG DOMAIN=domain1
 
 ENV HOME_DIR=/opt/dataverse\

--- a/docs/images.md
+++ b/docs/images.md
@@ -11,8 +11,8 @@ images to be used for the Dataverse deployment.
 
 Simple with Docker after cloning and accessing the source folder:
 ```
-docker build -t iqss/dataverse-k8s:4.15 docker/dataverse-k8s
-docker build -t iqss/solr-k8s:4.15 docker/solr-k8s
+docker build -t iqss/dataverse-k8s:4.15.1 docker/dataverse-k8s
+docker build -t iqss/solr-k8s:4.15.1 docker/solr-k8s
 ```
 *Please remember to change the tag above as appropriate. You should be*
 *using tagged images as best practice, not 'latest'.*

--- a/k8s/dataverse/deployment.yaml
+++ b/k8s/dataverse/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: dataverse
   labels:
     app.kubernetes.io/name: dataverse
-    app.kubernetes.io/version: "4.15"
+    app.kubernetes.io/version: "4.15.1"
     app.kubernetes.io/component: appserver
     app.kubernetes.io/part-of: dataverse
     app.kubernetes.io/managed-by: kubectl
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: dataverse
-          image: iqss/dataverse-k8s:4.15
+          image: iqss/dataverse-k8s:4.15.1
           ports:
             - containerPort: 8080
           envFrom:

--- a/k8s/dataverse/jobs/bootstrap.yaml
+++ b/k8s/dataverse/jobs/bootstrap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: bootstrap-dataverse
   labels:
     app.kubernetes.io/name: bootstrap
-    app.kubernetes.io/version: "4.15"
+    app.kubernetes.io/version: "4.15.1"
     app.kubernetes.io/component: job
     app.kubernetes.io/part-of: dataverse
     app.kubernetes.io/managed-by: kubectl
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: dv-bootstrap
-          image: iqss/dataverse-k8s:4.15
+          image: iqss/dataverse-k8s:4.15.1
           command: ["scripts/bootstrap-job.sh"]
           envFrom:
             - configMapRef:

--- a/k8s/dataverse/jobs/configure.yaml
+++ b/k8s/dataverse/jobs/configure.yaml
@@ -5,7 +5,7 @@ metadata:
   generateName: configure-dataverse-
   labels:
     app.kubernetes.io/name: configure
-    app.kubernetes.io/version: "4.15"
+    app.kubernetes.io/version: "4.15.1"
     app.kubernetes.io/component: job
     app.kubernetes.io/part-of: dataverse
     app.kubernetes.io/managed-by: kubectl
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: dv-bootstrap
-          image: iqss/dataverse-k8s:4.15
+          image: iqss/dataverse-k8s:4.15.1
           command: ["scripts/config-job.sh"]
           envFrom:
             - configMapRef:

--- a/k8s/solr/deployment.yaml
+++ b/k8s/solr/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: solr
   labels:
     app.kubernetes.io/name: solr
-    app.kubernetes.io/version: "4.15"
+    app.kubernetes.io/version: "4.15.1"
     app.kubernetes.io/component: searchindex
     app.kubernetes.io/part-of: dataverse
     app.kubernetes.io/managed-by: kubectl
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: solr
-          image: iqss/solr-k8s:4.15
+          image: iqss/solr-k8s:4.15.1
           ports:
             - containerPort: 8983
           volumeMounts:


### PR DESCRIPTION
Fixes #77.

The Solr config hasn't been touched in this patch release, so the image can be retagged unchanged to v4.15.1.