### PR TITLE
Use securityContext.fsGroup instead of initContainer.

### DIFF
--- a/k8s/dataverse/deployment.yaml
+++ b/k8s/dataverse/deployment.yaml
@@ -56,13 +56,8 @@ spec:
             httpGet:
               path: /robots.txt
               port: 8080
-      initContainers:
-        - name: volume-mount-hack
-          image: busybox
-          command: ["sh", "-c", "chown -c 1000:1000 /data"]
-          volumeMounts:
-          - name: files
-            mountPath: /data
+      securityContext:
+        fsGroup: 1000
       volumes:
         - name: files
           persistentVolumeClaim:

--- a/k8s/solr/deployment.yaml
+++ b/k8s/solr/deployment.yaml
@@ -33,13 +33,8 @@ spec:
           env:
             - name: SOLR_PORT  # Otherwise, this is wrongfully set by K8s.
               value: "8983"
-      initContainers:
-        - name: volume-mount-hack
-          image: busybox
-          command: ["sh", "-c", "chown -c 8983:8983 /data"]
-          volumeMounts:
-          - name: data
-            mountPath: /data
+      securityContext:
+        fsGroup: 8983
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
Remove the initContainer as this will be handled by securityContext.fsGroup arguments in the deployment.
Tested on Google Cloud Platform and Minikube.