### PR TITLE
fix links (.rst instead of .md) #92

### DIFF
--- a/docs/day1/secrets.rst
+++ b/docs/day1/secrets.rst
@@ -155,8 +155,8 @@ in the upstream documentation and below.
 .. todo::
   Write more things, link stuff.
 
-Please use [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) and *mount them as volumes*.
-See also [here](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume).
+Please use `Kubernetes Secrets <https://kubernetes.io/docs/concepts/configuration/secret/>`_ and *mount them as volumes*.
+See also `here <https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume>`_.
 
 
 Secure storage and distribution


### PR DESCRIPTION
This should fix these links:

![Screen Shot 2020-01-03 at 3 10 01 PM](https://user-images.githubusercontent.com/21006/71746530-26f8a900-2e3b-11ea-9579-1505f70c6730.png)
